### PR TITLE
Output html

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     version=get_version(),
     author='Marc Abramowitz',
     author_email='msabramo@gmail.com',
-    install_requires=['mock'],
+    install_requires=['click', 'mock'],
     entry_points="""\
         [console_scripts]
         setuppycheck = setuppycheck:setuppycheck

--- a/setuppycheck.py
+++ b/setuppycheck.py
@@ -9,6 +9,8 @@ import mock
 import os
 import sys
 
+import click
+
 level = logging.INFO
 # level = logging.DEBUG
 logging.basicConfig(level=level)
@@ -39,7 +41,7 @@ def open(name, **kwargs):
 
     if 'requirements' in name:
         warnings_output_file.write(
-            'WARNING: reads %r - looks like a requirements file?\n'
+            'WARNING: reads %s - looks like a requirements file?\n'
             % name)
         warnings_output_file.write(
             '  You might want to look at '
@@ -49,11 +51,10 @@ def open(name, **kwargs):
     return orig_open(name, **kwargs)
 
 
-def setuppycheck(argv=None):
-    if argv is None:
-        argv = sys.argv[1:]
-
-    for setuppy in argv:
+@click.command()
+@click.argument('setuppy_file_paths', nargs=-1, required=True)
+def setuppycheck(setuppy_file_paths):
+    for setuppy in setuppy_file_paths:
         setuppy = os.path.realpath(setuppy)
 
         with mock.patch('setuptools.setup', side_effect=setup):
@@ -76,7 +77,3 @@ def setuppycheck(argv=None):
                 execfile(setuppy, execfile_globals)
 
     return 0 if is_setuppy_ok else 1
-
-
-if __name__ == '__main__':
-    sys.exit(setuppycheck())

--- a/setuppycheck.py
+++ b/setuppycheck.py
@@ -19,41 +19,83 @@ logger = logging.getLogger(__name__)
 orig_open = __builtin__.open
 is_setuppy_ok = True
 warnings_output_file = sys.stderr
+output_format = 'text'
+setup_vs_requirement_link = 'https://caremad.io/2013/07/setup-vs-requirement/'
+
+
+def link(url):
+    return '<a href="%(url)s">%(url)s</a>' % {'url': url}
+
+
+class ExactPinWarning(object):
+    def __init__(self, req):
+        self.req = req
+
+    def emit(self, output_file, output_format):
+        if output_format == 'html':
+            output_file.write(
+                '<li>WARNING: exact pin: %r</li>\n' % self.req)
+        else:
+            output_file.write(
+                'WARNING: exact pin: %r\n' % self.req)
+
+
+class ReadsRequirementsFileWarning(object):
+    def __init__(self, name):
+        self.name = name
+
+    def emit(self, output_file, output_format='text'):
+        if output_format == 'html':
+            output_file.write(
+                '<li>WARNING: reads %s - '
+                'looks like a requirements file?<br/>\n'
+                % self.name)
+            output_file.write(
+                '    You might want to look at %s</li>\n'
+                % link(setup_vs_requirement_link))
+        else:
+            output_file.write(
+                'WARNING: reads %s - '
+                'looks like a requirements file?\n'
+                % self.name)
+            output_file.write(
+                '    You might want to look at %s\n'
+                % setup_vs_requirement_link)
 
 
 def setup(**kwargs):
-    global is_setuppy_ok
+    global is_setuppy_ok, output_format
 
     install_requires = kwargs.get('install_requires')
     logger.debug('install_requires = %r' % install_requires)
 
     for req in install_requires:
         if '==' in req:
-            warnings_output_file.write(
-                'WARNING: exact pin: %r\n' % req)
+            ExactPinWarning(req).emit(warnings_output_file, output_format)
             is_setuppy_ok = False
 
 
 def open(name, **kwargs):
-    global is_setuppy_ok
+    global is_setuppy_ok, output_format
 
     logger.debug('open: %s', name)
 
     if 'requirements' in name:
-        warnings_output_file.write(
-            'WARNING: reads %s - looks like a requirements file?\n'
-            % name)
-        warnings_output_file.write(
-            '  You might want to look at '
-            'https://caremad.io/2013/07/setup-vs-requirement/\n')
+        ReadsRequirementsFileWarning(name).emit(
+            warnings_output_file, output_format)
         is_setuppy_ok = False
 
     return orig_open(name, **kwargs)
 
 
 @click.command()
-@click.argument('setuppy_file_paths', nargs=-1, required=True)
-def setuppycheck(setuppy_file_paths):
+@click.argument('setuppy_file_paths', nargs=-1)
+@click.option('--output-format',
+              type=click.Choice(['text', 'html']), default='text',
+              help='Output warnings in HTML')
+def setuppycheck(output_format, setuppy_file_paths):
+    globals()['output_format'] = output_format
+
     for setuppy in setuppy_file_paths:
         setuppy = os.path.realpath(setuppy)
 
@@ -76,4 +118,9 @@ def setuppycheck(setuppy_file_paths):
                 os.chdir(os.path.dirname(setuppy))
                 execfile(setuppy, execfile_globals)
 
-    return 0 if is_setuppy_ok else 1
+    exit_code = 0 if is_setuppy_ok else 1
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    setuppycheck()


### PR DESCRIPTION
This adds support for HTML output, which is a bit nicer when being invoked from the CI pipeline, because then we can have clickable links and such.

```
$ setuppycheck --output-format=html ~/dev/surveymonkey/mobileweb/setup.py
<li>WARNING: reads /Users/marca/dev/surveymonkey/mobileweb/requirements.txt - might be a requirements file?<br/>
    You might want to look at <a href="https://caremad.io/2013/07/setup-vs-requirement/">https://caremad.io/2013/07/setup-vs-requirement/</a></li>
<li>WARNING: reads /Users/marca/dev/surveymonkey/mobileweb/test-requirements.txt - might be a requirements file?<br/>
    You might want to look at <a href="https://caremad.io/2013/07/setup-vs-requirement/">https://caremad.io/2013/07/setup-vs-requirement/</a></li>
<li>WARNING: exact pin: 'boto==2.34.0'</li>
<li>WARNING: exact pin: 'httplib2==0.8'</li>
<li>WARNING: exact pin: 'pycrypto==2.5'</li>
<li>WARNING: exact pin: 'pyramid==1.5.4'</li>
<li>WARNING: exact pin: 'PyYAML==3.10'</li>
<li>WARNING: exact pin: 'redis==2.6.2'</li>
<li>WARNING: exact pin: 'smsdk.surveysvc==0.1.40'</li>
<li>WARNING: exact pin: 'RAttr==0.6.2'</li>
<li>WARNING: exact pin: 'SMCrypto==0.2.22-compat'</li>
<li>WARNING: exact pin: 'smlib.assets==1.3.0'</li>
<li>WARNING: exact pin: 'smlib.auth==2.4.4'</li>
<li>WARNING: exact pin: 'smlib.date==0.0.3'</li>
<li>WARNING: exact pin: 'smlib.enums==0.0.4'</li>
<li>WARNING: exact pin: 'smlib.errorviews==2.3.1'</li>
<li>WARNING: exact pin: 'smlib.service==1.2.0'</li>
<li>WARNING: exact pin: 'smlib.validate==1.0.1'</li>
<li>WARNING: exact pin: 'smlib.web==1.4.5'</li>
<li>WARNING: exact pin: 'smlib.webmodels==0.0.36-no-version'</li>
<li>WARNING: exact pin: 'smpackage==0.22'</li>
<li>WARNING: exact pin: 'smsdk.ansvc==0.0.7'</li>
<li>WARNING: exact pin: 'smsdk.authsvc==0.0.8'</li>
<li>WARNING: exact pin: 'smsdk.responsesvc==0.0.1'</li>
<li>WARNING: exact pin: 'smsdk.collectsvc==0.0.23'</li>
<li>WARNING: exact pin: 'smsdk.billsvc==0.0.6'</li>
<li>WARNING: exact pin: 'smsdk.s3==1.0.0'</li>
<li>WARNING: exact pin: 'smlib.uploader==1.1.0'</li>
<li>WARNING: exact pin: 'smsdk.usersvc==1.0.12'</li>
<li>WARNING: exact pin: 'smlib.locale==1.0.0'</li>
<li>WARNING: exact pin: 'smlib.cache==1.0.20'</li>
<li>WARNING: exact pin: 'gunicorn==19.2.1'</li>
<li>WARNING: exact pin: 'PasteDeploy==1.5.2'</li>
<li>WARNING: exact pin: 'smlib.log==1.2.0'</li>
<li>WARNING: exact pin: 'mobusersvc==1.0.56'</li>
<li>WARNING: exact pin: 'smsdk.acsvc==0.0.10'</li>
<li>WARNING: exact pin: 'smsdk.qbsvc==0.0.3'</li>
<li>WARNING: exact pin: 'newrelic==2.50.0.39'</li>
```

Cc: @sudarkoff, @aconrad
